### PR TITLE
Closing tags messing with quotes

### DIFF
--- a/grammars/smarty.cson
+++ b/grammars/smarty.cson
@@ -20,11 +20,11 @@ repository:
   blocks:
     patterns: [
       {
-        begin: "(\\{%?)"
+        begin: "(\\[\"\']{%?)"
         beginCaptures:
           "1":
             name: "punctuation.section.embedded.begin.smarty"
-        end: "(%?\\})"
+        end: "(%?\\}[\"\']?)"
         endCaptures:
           "1":
             name: "punctuation.section.embedded.end.smarty"


### PR DESCRIPTION
As reported in https://github.com/MaxGiting/atom-language-smarty/issues/12

Added quotations into the pattern into the blocks, so now the highlighter don't think everything else is a string.